### PR TITLE
Set UTF-8 encoding for reading `pandoc-crossref.yaml`

### DIFF
--- a/lib/Text/Pandoc/CrossRef/Util/Settings.hs
+++ b/lib/Text/Pandoc/CrossRef/Util/Settings.hs
@@ -10,6 +10,7 @@ import Text.Pandoc.CrossRef.Util.Meta
 import Text.Pandoc.CrossRef.Util.PandocOrphans()
 import System.Directory
 import System.FilePath
+import System.IO
 
 getSettings :: Maybe Format -> Meta -> IO Meta
 getSettings fmt meta = do
@@ -21,7 +22,9 @@ getSettings fmt meta = do
   where
     readConfig path =
       handle handler $ do
-        yaml <- readFile path
+        h <- openFile path ReadMode
+        hSetEncoding h utf8
+        yaml <- hGetContents h
         let Pandoc meta' _ = readMarkdown def ("---\n" ++ yaml ++ "\n---")
         return meta'
     readFmtConfig home fmt' = readConfig (home </> ".pandoc-crossref" </> "config-" ++ fmtStr fmt' ++ ".yaml")


### PR DESCRIPTION
If the system encoding is not UTF-8 (e.g. Windows),
UTF-8 encoded `pandoc-crossref.yaml` reading was broken.

This commit makes pandoc-crossref set UTF-8 encoding
for reading `pandoc-crossref.yaml`.

So even if on Windows,
UTF-8 encoded `pandoc-crossref.yaml` can be read.