### PR TITLE
Force search for ':' after crossreference prefix

### DIFF
--- a/lib/Text/Pandoc/CrossRef/References/Refs.hs
+++ b/lib/Text/Pandoc/CrossRef/References/Refs.hs
@@ -75,7 +75,7 @@ allCitsPrefix :: Options -> [Citation] -> Maybe String
 allCitsPrefix opts cits = find isCitationPrefix $ prefixList opts
   where
   isCitationPrefix p =
-    all (p `isPrefixOf`) $ map (uncapitalizeFirst . citationId) cits
+    all ((p ++ ":") `isPrefixOf`) $ map (uncapitalizeFirst . citationId) cits
 
 replaceRefsLatex :: String -> Options -> [Citation] -> WS Inlines
 replaceRefsLatex prefix opts cits


### PR DESCRIPTION
Haskell noob here. Please let me know if I've misunderstood how it all fits together.

-----

In the any-prefix branch, there is an issue where _citations_ that start with characters that match a _cross-reference prefix_ will be treated as cross-references.

As an example, I have a citation to `[@Figueroa2012-tu]` in my current document.
Because this starts with 'fig', it is rendered as `fig.~\ref{Figueroa2012-tu}` in LaTeX, rather than `\autocite{Figueroa2012-tu}`. (I originally found this bug because I introduced a customised 'cl' crossref prefix, and this ruined all my cites to `@Clark`, etc.)

I believe this is happening because References/Refs.hs::replaceRefs matches this `cits'` to the (Just prefix) branch, because ::allCitsPrefix is only looking to match against one of the entries in `prefixList` (e.g. `fig`, in the defaults specified in Util/Settings.hs::defaultMeta).

In the master branch, this bug doesn't happen, because the matching in References/Refs.hs::allCitsPrefix is against one of the entries in ::accMap. These entries already include a colon—i.e. they're listed as `fig:`—so matching `Figueroa` would fall through and be treated correctly as a Cite.

This patch simply makes sure that crossreference prefixes must be followed by a colon (more like the behaviour in master).