### PR TITLE
hint at Windows installation via scoop

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ time of writing, pandoc-crossref is provided on the following platforms
 -   FreeBSD official binary package [textproc/hs-pandoc-crossref](https://www.freshports.org/textproc/hs-pandoc-crossref/)
 -   Any Linux distribution (via [Linuxbrew](https://docs.brew.sh/Linuxbrew))
 -   Gentoo Linux (via gentoo-haskell overlay)
+-   Windows (via [scoop](https://scoop.sh/))
 
 ### Building from Hackage with `cabal-install` and Haskell platform
 


### PR DESCRIPTION
Scoop's default repository of available applications (the main bucket) contains pandoc-crossref and appears to be [kept up to date](https://github.com/ScoopInstaller/Main/commits/master/bucket/pandoc-crossref.json) (it updates usually within two days of a new release).

[scoop](https://scoop.sh/) is a console package manager for windows, primarily for console applications. It downloads releases directly from pandoc-crossref's Github repository.

To me, `scoop install pandoc-crossref` thus seems like the quickest way to install it on 64-bit Windows. I suggest adding it to the readme.


I might also point out that [Chocolatey](https://chocolatey.org/), a sad alternative package manager for Windows, lists [pandoc-crossref](https://chocolatey.org/packages/pandoc-crossref/) as well, however it's quite outdated (0.3.4.1) and appears unmaintained.