### PR TITLE
Complete purge of pandoc-citeproc references

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Copy build config
       shell: bash
       run: cp misc/${{runner.os}}-build-cabal-config ./cabal.project
-    - name: Cabal confugure
+    - name: Cabal configure
       run: cabal v2-configure --constraint pandoc==${{matrix.pandocver}} --enable-tests
     - uses: actions/cache@v2
       with:

--- a/README.md
+++ b/README.md
@@ -88,10 +88,10 @@ If you have `cabal-install` version 3.0 or newer (i.e. `cabal --version` shows `
 
 ``` bash
 cabal v2-update
-cabal v2-install --install-method=copy pandoc pandoc-crossref pandoc-citeproc
+cabal v2-install --install-method=copy pandoc pandoc-crossref
 ```
 
-This will get `pandoc-crossref`, `pandoc` and `pandoc-citeproc` executables copied to `$HOME/.cabal/bin` (by default, if not, check your cabal config file `installdir` setting -- find out where your config file is by running `cabal help user-config`), which you can then add to `PATH` or copy/move the symlinks where you want them.
+This will get `pandoc-crossref` and `pandoc` executables copied to `$HOME/.cabal/bin` (by default, if not, check your cabal config file `installdir` setting -- find out where your config file is by running `cabal help user-config`), which you can then add to `PATH` or copy/move the symlinks where you want them.
 
 On cabal-install version 2.4, it's possible to do the same, albeit you'll have to lose `--install-method copy`, it will symlink the executables instead of copying those, and it doesn't work on Windows.
 
@@ -104,10 +104,10 @@ cabal update
 mkdir pandoc-crossref
 cd pandoc-crossref
 cabal sandbox init
-cabal install pandoc pandoc-crossref pandoc-citeproc
+cabal install pandoc pandoc-crossref
 ```
 
-This will get `pandoc`, `pandoc-citeproc`, and `pandoc-crossref` installed into `.cabal-sandbox/bin`.
+This will get `pandoc` and `pandoc-crossref` installed into `.cabal-sandbox/bin`.
 
 Refer to cabal documentation if you need to build a particular version (TL;DR: add `--constraint pandoc-crossref==<version>` to the installation command)
 
@@ -130,7 +130,7 @@ stack install
 
 If you don't have `git`, just download the sources for your preferred commit/branch/tag via the GitHub interface, and run `stack install` in the directory that contains `stack.yaml` file.
 
-This will install pandoc-crossef executable to `$HOME/.local/bin`. You might also want to separately run `stack install pandoc pandoc-citeproc` in the same directory (i.e. the root of the repository, the one containing `stack.yaml` file)
+This will install pandoc-crossef executable to `$HOME/.local/bin`. You might also want to separately run `stack install pandoc` in the same directory (i.e. the root of the repository, the one containing `stack.yaml` file)
 
 ### Notice Fedora users
 

--- a/cabal.project
+++ b/cabal.project
@@ -3,5 +3,3 @@ package citeproc
   ghc-options: -j +RTS -A64m -RTS
 package pandoc
   ghc-options: -j +RTS -A64m -RTS
-package pandoc-crossref
-  ghc-options: -j +RTS -A64m -RTS

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,10 +37,6 @@ you *have* to run former *before* latter. For example:
 
     pandoc -F pandoc-crossref --citeproc file.md -o file.html
 
-or
-
-    pandoc -F pandoc-crossref -F pandoc-citeproc file.md -o file.html
-
 ## Note on leading/trailing spaces in metadata options
 
 Leading and trailing spaces in YAML metadata will most likely be

--- a/misc/cabal.project
+++ b/misc/cabal.project
@@ -4,15 +4,6 @@ package pandoc
   flags: +embed_data_files -trypandoc
   ghc-options: -j +RTS -A32M -RTS
 
-package pandoc-citeproc
-  flags: +embed_data_files +bibutils -unicode_collation -test_citeproc -debug
-  ghc-options: -j +RTS -A32M -RTS
-
-source-repository-package
-    type: git
-    location: https://github.com/jgm/pandoc-citeproc
-    tag: 0.16.3
-
 source-repository-package
   type: git
   location: https://github.com/jgm/doctemplates.git

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,7 +3,6 @@ flags:
     enable_flaky_tests: true
 ghc-options:
   pandoc: -j "+RTS -A64m -RTS"
-  pandoc-citeproc: -j "+RTS -A64m -RTS"
   $targets: -j "+RTS -A64m -RTS"
 packages:
 - .


### PR DESCRIPTION
Using pandoc-citeproc on its own is deprecated for half a year now, so
point to the main pandoc project instead. Fixes: 6c04248

Note: misc/cabal.project pinned the pandoc-citeproc version to 0.16.3, 
released 2019-09-26. The entire reference has been removed presuming it 
wouldn't have worked with modern pandoc anyway