### PR TITLE
Replace \qquad for equation numbering by \tag

### DIFF
--- a/lib-internal/Text/Pandoc/CrossRef/References/Blocks.hs
+++ b/lib-internal/Text/Pandoc/CrossRef/References/Blocks.hs
@@ -307,7 +307,7 @@ replaceEqn opts (label, _, attrs) eq = do
              | otherwise = Right label
   idxStr <- replaceAttr opts label' (lookup "label" attrs) [] eqnRefs
   let eq' | tableEqns opts = eq
-          | otherwise = eq<>"\\qquad("<>idxTxt<>")"
+          | otherwise = eq<>"\\tag{"<>idxTxt<>"}"
       idxTxt = stringify idxStr
   return (eq', idxStr)
 


### PR DESCRIPTION
The current solution of adding spacing to the equation number by \quad breaks the layout conventions of amsmath. The standard way of influencing the label an equation is displayed with is to use \tag, which is supported by KaTeX. This seems to be a nice way of ensuring that the equation numbers are right aligned, which is not guaranteed by either \quad or the tableLayout option. To maintain backward compatibility it might be a better idea to introduce this as an option instead of modifying the old behaviour.