### PR TITLE
Allow pandoc 2.14.2

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -8,11 +8,12 @@ packages:
 - .
 extra-deps:
 - roman-numerals-0.5.1.5
-- pandoc-2.14.1
-- citeproc-0.4.1
+- pandoc-2.14.2
+- citeproc-0.5
 - commonmark-pandoc-0.2.1.1
 - doctemplates-0.10
 - skylighting-0.11
 - skylighting-core-0.11
 - commonmark-0.2.1
+- texmath-0.12.3.1
 resolver: lts-18.0


### PR DESCRIPTION
It builds fine and seems to work just fine here.  
pandoc 2.14.1 adds native_numbering, which does not seem to be optionally disableable. native_numbering conflicts with pandoc-crossref and generates unintended docx files.

https://github.com/jgm/pandoc/issues/7499

It is now possible to disable it in the 2.14.2 version, so it would be very nice to have a build for pandoc 2.14.2 in pandoc-crossref.

