### PR TITLE
Update haskell.yml to pandoc version 3.1.2

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        pandocver: ["3.1.1"]
+        pandocver: ["3.1.2"]
         ghcver: ['9.0.2']
         include:
         - os: ubuntu-latest


### PR DESCRIPTION
Should fix the following warning:

`WARNING: pandoc-crossref was compiled with pandoc 3.1.1 but is being run through 3.1.2. This is not supported. Strange things may (and likely will) happen silently.`

I am not familiar with the projects inner workings, so this might need more changes to work, but I am hoping it is just a simple version bump.