### PR TITLE
Make compatible with pandoc 3.1.6.2

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -3,7 +3,7 @@ name: Haskell CI
 on: [push]
 
 env:
-  PANDOC_VERSION: "3.1.6.1"
+  PANDOC_VERSION: "3.1.6.2"
 
 jobs:
   build:

--- a/stack.yaml
+++ b/stack.yaml
@@ -181,7 +181,7 @@ extra-deps:
 - open-browser-0.2.1.0
 - optparse-applicative-0.17.1.0
 - ordered-containers-0.2.3
-- pandoc-3.1.6.1
+- pandoc-3.1.6.2
 - pandoc-cli-0.1.1.1
 - pandoc-lua-engine-0.2.1.1
 - pandoc-lua-marshal-0.2.2
@@ -234,7 +234,7 @@ extra-deps:
 - tagsoup-0.14.8
 - template-haskell-2.19.0.0
 - temporary-1.3
-- texmath-0.12.8
+- texmath-0.12.8.1
 - text-2.0.2
 - text-conversions-0.3.1.1
 - text-short-0.1.5
@@ -254,8 +254,8 @@ extra-deps:
 - transformers-compat-0.7.2
 - type-equality-1
 - typed-process-0.2.11.0
-- typst-0.3.1.0
-- typst-symbols-0.1.2
+- typst-0.3.2.0
+- typst-symbols-0.1.4
 - unicode-collation-0.1.3.4
 - unicode-data-0.4.0.1
 - unicode-transforms-0.4.0.1

--- a/test/m2m/chapDelim/expect.tex
+++ b/test/m2m/chapDelim/expect.tex
@@ -1,14 +1,9 @@
-\hypertarget{sec:section}{%
-\section{1 Section}\label{sec:section}}
+\section{1 Section}\label{sec:section}
 
-\hypertarget{sec:subsection}{%
-\subsection{1delim1 Subsection}\label{sec:subsection}}
+\subsection{1delim1 Subsection}\label{sec:subsection}
 
-\hypertarget{sec:subsubsection}{%
-\subsubsection{1delim1delim1 Subsubsection}\label{sec:subsubsection}}
+\subsubsection{1delim1delim1 Subsubsection}\label{sec:subsubsection}
 
-\hypertarget{sec:section-1}{%
-\section{2 Section}\label{sec:section-1}}
+\section{2 Section}\label{sec:section-1}
 
-\hypertarget{sec:subsubsection-1}{%
-\subsubsection{2delim1delim1 Subsubsection}\label{sec:subsubsection-1}}
+\subsubsection{2delim1delim1 Subsubsection}\label{sec:subsubsection-1}

--- a/test/m2m/emptyChapterLabels/expect.tex
+++ b/test/m2m/emptyChapterLabels/expect.tex
@@ -1,8 +1,6 @@
-\hypertarget{sec:section}{%
-\section{1 Section}\label{sec:section}}
+\section{1 Section}\label{sec:section}
 
-\hypertarget{sec:subsection}{%
-\subsection{1 Subsection}\label{sec:subsection}}
+\subsection{1 Subsection}\label{sec:subsection}
 
 \begin{figure}
 \hypertarget{fig:figure1}{%
@@ -12,14 +10,11 @@
 }
 \end{figure}
 
-\hypertarget{sec:subsubsection}{%
-\subsubsection{1.1 Subsubsection}\label{sec:subsubsection}}
+\subsubsection{1.1 Subsubsection}\label{sec:subsubsection}
 
-\hypertarget{sec:section-1}{%
-\section{2 Section}\label{sec:section-1}}
+\section{2 Section}\label{sec:section-1}
 
-\hypertarget{sec:subsubsection-1}{%
-\subsubsection{2.1.1 Subsubsection}\label{sec:subsubsection-1}}
+\subsubsection{2.1.1 Subsubsection}\label{sec:subsubsection-1}
 
 sec.~\ref{sec:subsubsection}
 

--- a/test/m2m/label-precedence/expect.tex
+++ b/test/m2m/label-precedence/expect.tex
@@ -1,5 +1,4 @@
-\hypertarget{first-section}{%
-\section{* First Section}\label{first-section}}
+\section{* First Section}\label{first-section}
 
 text
 
@@ -11,8 +10,7 @@ text
 }
 \end{figure}
 
-\hypertarget{subsection}{%
-\subsection{*.A Subsection}\label{subsection}}
+\subsection{*.A Subsection}\label{subsection}
 
 other text
 
@@ -24,13 +22,11 @@ other text
 }
 \end{figure}
 
-\hypertarget{subsubsection}{%
-\subsubsection{*.A.A Subsubsection}\label{subsubsection}}
+\subsubsection{*.A.A Subsubsection}\label{subsubsection}
 
 text text text
 
-\hypertarget{custom-on-other-elements}{%
-\section{B Custom on other elements}\label{custom-on-other-elements}}
+\section{B Custom on other elements}\label{custom-on-other-elements}
 
 \begin{figure}
 \hypertarget{fig:fig3}{%

--- a/test/m2m/numberOverride/expect.tex
+++ b/test/m2m/numberOverride/expect.tex
@@ -1,8 +1,6 @@
-\hypertarget{section}{%
-\section{1 Section}\label{section}}
+\section{1 Section}\label{section}
 
-\hypertarget{earlier-subsection}{%
-\subsection{1.1 Earlier Subsection}\label{earlier-subsection}}
+\subsection{1.1 Earlier Subsection}\label{earlier-subsection}
 
 \begin{figure}
 \hypertarget{fig:img1}{%
@@ -12,8 +10,7 @@
 }
 \end{figure}
 
-\hypertarget{title-of-subsection}{%
-\subsection{1.6 Title of Subsection}\label{title-of-subsection}}
+\subsection{1.6 Title of Subsection}\label{title-of-subsection}
 
 \begin{figure}
 \hypertarget{fig:img2}{%
@@ -39,8 +36,7 @@
 }
 \end{figure}
 
-\hypertarget{title-of-subsection-1}{%
-\subsection{1.7 Title of Subsection}\label{title-of-subsection-1}}
+\subsection{1.7 Title of Subsection}\label{title-of-subsection-1}
 
 \begin{figure}
 \hypertarget{fig:img21}{%

--- a/test/m2m/secLabels/expect.tex
+++ b/test/m2m/secLabels/expect.tex
@@ -1,8 +1,6 @@
-\hypertarget{first-level-section}{%
-\section{a First Level Section}\label{first-level-section}}
+\section{a First Level Section}\label{first-level-section}
 
-\hypertarget{second-level-section}{%
-\subsection{a.a Second Level Section}\label{second-level-section}}
+\subsection{a.a Second Level Section}\label{second-level-section}
 
 \begin{figure}
 \hypertarget{fig:myfig}{%
@@ -12,9 +10,8 @@
 }
 \end{figure}
 
-\hypertarget{other-second-level-section}{%
 \subsection{a.b Other Second Level
-Section}\label{other-second-level-section}}
+Section}\label{other-second-level-section}
 
 \hypertarget{tbl:mytable}{}
 \begin{longtable}[]{@{}lll@{}}

--- a/test/m2m/secLevelLabels/expect.tex
+++ b/test/m2m/secLevelLabels/expect.tex
@@ -1,14 +1,11 @@
-\hypertarget{first-section}{%
-\section{A. First Section}\label{first-section}}
+\section{A. First Section}\label{first-section}
 
 text
 
-\hypertarget{subsection}{%
-\subsection{A.1) Subsection}\label{subsection}}
+\subsection{A.1) Subsection}\label{subsection}
 
 other text
 
-\hypertarget{subsubsection}{%
-\subsubsection{A.1.i Subsubsection}\label{subsubsection}}
+\subsubsection{A.1.i Subsubsection}\label{subsubsection}
 
 text text text

--- a/test/m2m/section-template/expect.tex
+++ b/test/m2m/section-template/expect.tex
@@ -1,19 +1,13 @@
-\hypertarget{first-level-section}{%
-\section{Chapter 1. First Level Section}\label{first-level-section}}
+\section{Chapter 1. First Level Section}\label{first-level-section}
 
-\hypertarget{second-level-section}{%
 \subsection{Section 1.1. Second Level
-Section}\label{second-level-section}}
+Section}\label{second-level-section}
 
-\hypertarget{thrid-level-section}{%
 \subsubsection{Paragraph 1.1.1. Thrid Level
-Section}\label{thrid-level-section}}
+Section}\label{thrid-level-section}
 
-\hypertarget{fourth-level-section}{%
-\paragraph{1.1.1.1. Fourth Level Section}\label{fourth-level-section}}
+\paragraph{1.1.1.1. Fourth Level Section}\label{fourth-level-section}
 
-\hypertarget{fifth-level-section}{%
-\subparagraph{1.1.1.1.1. Fifth Level
-Section}\label{fifth-level-section}}
+\subparagraph{1.1.1.1.1. Fifth Level Section}\label{fifth-level-section}
 
 1.1.1.1.1.1. Sixth Level Section

--- a/test/m2m/setLabelAttribute/expect.tex
+++ b/test/m2m/setLabelAttribute/expect.tex
@@ -1,5 +1,4 @@
-\hypertarget{section}{%
-\section{Section}\label{section}}
+\section{Section}\label{section}
 
 \begin{figure}
 \hypertarget{fig:1}{%
@@ -39,5 +38,4 @@ code
 
 \end{codelisting}
 
-\hypertarget{section-1}{%
-\subsection{Section}\label{section-1}}
+\subsection{Section}\label{section-1}

--- a/test/m2m/subfigures-one-row/expect.tex
+++ b/test/m2m/subfigures-one-row/expect.tex
@@ -1,5 +1,4 @@
-\hypertarget{figures}{%
-\section{Figures}\label{figures}}
+\section{Figures}\label{figures}
 
 Regression test for
 \href{https://github.com/lierdakil/pandoc-crossref/issues/381}{\#381}

--- a/test/m2m/titlesInRefs/expect.tex
+++ b/test/m2m/titlesInRefs/expect.tex
@@ -1,5 +1,4 @@
-\hypertarget{sec:section}{%
-\section{Section}\label{sec:section}}
+\section{Section}\label{sec:section}
 
 \begin{figure}
 \hypertarget{fig:figure}{%

--- a/test/test-pandoc-crossref.hs
+++ b/test/test-pandoc-crossref.hs
@@ -302,7 +302,7 @@ main = hspec $ do
         it "Section labels" $
           headerWith ("sec:section_label1", [], []) 1 (text "Section")
             <> para (citeGen "sec:section_label" [1])
-            `test` "\\hypertarget{sec:section_label1}{%\n\\section{Section}\\label{sec:section_label1}}\n\nsec.~\\ref{sec:section_label1}"
+            `test` "\\section{Section}\\label{sec:section_label1}\n\nsec.~\\ref{sec:section_label1}"
 
         it "Image labels" $
           figure "img.png" "" "Title" Nothing "figure_label1"


### PR DESCRIPTION
Pandoc dropped \hypertarget invocations from section headings in jgm/pandoc@70329ed
Updated test expectations, also bumped minimal version bounds as demanded by pandoc
Closes: #399

(Forgot to update github workflow, and accidentally closed #400. Sorry for mess)