### PR TITLE
Allow optparse-applicative 0.18* and mtl 2.3*

### DIFF
--- a/lib-internal/Text/Pandoc/CrossRef/References/Blocks/Header.hs
+++ b/lib-internal/Text/Pandoc/CrossRef/References/Blocks/Header.hs
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 module Text.Pandoc.CrossRef.References.Blocks.Header where
 
+import Control.Monad
 import Control.Monad.Reader.Class
 import Control.Monad.State hiding (get, modify)
 import qualified Data.Map as M

--- a/lib-internal/Text/Pandoc/CrossRef/References/Blocks/Subfigures.hs
+++ b/lib-internal/Text/Pandoc/CrossRef/References/Blocks/Subfigures.hs
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 module Text.Pandoc.CrossRef.References.Blocks.Subfigures where
 
+import Control.Monad
 import Control.Monad.Reader
 import Control.Monad.State hiding (get, modify)
 import qualified Data.Map as M

--- a/lib-internal/Text/Pandoc/CrossRef/References/Blocks/Util.hs
+++ b/lib-internal/Text/Pandoc/CrossRef/References/Blocks/Util.hs
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 module Text.Pandoc.CrossRef.References.Blocks.Util where
 
+import Control.Monad
 import Control.Monad.Reader.Class
 import Control.Monad.State hiding (get, modify)
 import qualified Data.Map as M

--- a/lib-internal/Text/Pandoc/CrossRef/References/Refs.hs
+++ b/lib-internal/Text/Pandoc/CrossRef/References/Refs.hs
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 module Text.Pandoc.CrossRef.References.Refs (replaceRefs) where
 
 import Control.Arrow as A
+import Control.Monad
 import Control.Monad.Reader
 import Data.Function
 import Data.List

--- a/lib-internal/Text/Pandoc/CrossRef/Util/ModifyMeta.hs
+++ b/lib-internal/Text/Pandoc/CrossRef/Util/ModifyMeta.hs
@@ -24,6 +24,7 @@ module Text.Pandoc.CrossRef.Util.ModifyMeta
     modifyMeta
     ) where
 
+import Control.Monad
 import Control.Monad.Writer
 import qualified Data.Text as T
 import Text.Pandoc

--- a/pandoc-crossref.cabal
+++ b/pandoc-crossref.cabal
@@ -176,7 +176,7 @@ library pandoc-crossref-internal
     , microlens-ghc >=0.4.3.10 && <0.5.0.0
     , microlens-mtl >=0.2.0.1 && <0.3.0.0
     , microlens-th >=0.4.3.10 && <0.5.0.0
-    , mtl >=1.1 && <2.3
+    , mtl >=1.1 && <2.4
     , pandoc >=3.0 && <3.2
     , pandoc-types ==1.23.*
     , syb >=0.4 && <0.8
@@ -197,7 +197,7 @@ executable pandoc-crossref
     , deepseq ==1.4.*
     , gitrev >=1.3.1 && <1.4
     , open-browser ==0.2.*
-    , optparse-applicative >=0.13 && <0.18
+    , optparse-applicative >=0.13 && <0.19
     , pandoc >=3.0 && <3.2
     , pandoc-crossref
     , pandoc-types ==1.23.*
@@ -244,7 +244,7 @@ test-suite test-pandoc-crossref
     , data-default >=0.4 && <0.8
     , hspec >=2.4.4 && <3
     , microlens >=0.4.12.0 && <0.5.0.0
-    , mtl >=1.1 && <2.3
+    , mtl >=1.1 && <2.4
     , pandoc >=3.0 && <3.2
     , pandoc-crossref
     , pandoc-crossref-internal


### PR DESCRIPTION
mtl types stopped re-exporting Control.Monad